### PR TITLE
Allow docker-py Client class to use the API version provided by server

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -15,7 +15,7 @@ METRICS = None
 REFRESH_INTERVAL = os.environ.get('REFRESH_INTERVAL', 60)
 CONTAINER_REFRESH_INTERVAL = os.environ.get('CONTAINER_REFRESH_INTERVAL', 120)
 DOCKER_CLIENT = Client(
-    base_url=os.environ.get('DOCKER_CLIENT_URL', 'unix://var/run/docker.sock'))
+    base_url=os.environ.get('DOCKER_CLIENT_URL', 'unix://var/run/docker.sock'),version='auto')
 USE_PSEUDO_FILES = bool(os.environ.get('USE_PSEUDO_FILES', 1))
 CGROUP_DIRECTORY = os.environ.get('CGROUP_DIRECTORY', '/sys/fs/cgroup')
 PROC_DIRECTORY = os.environ.get('PROC_DIRECTORY', '/proc')
@@ -60,7 +60,7 @@ def handle_error(ex):
     response.status_code = getattr(ex, 'code', 500)
     DOCKER_CLIENT = Client(
         base_url=os.environ.get('DOCKER_CLIENT_URL',
-                                'unix://var/run/docker.sock'))
+                                'unix://var/run/docker.sock'),version='auto')
     METRICS = update_metrics()
     return response
 


### PR DESCRIPTION
The docker-py Client will default to a specific version of Docker API which may produce errors, such as the following:
`[2018-06-06 14:20:16,258] ERROR in application: 400 Client Error: Bad Request ("client is newer than server (client API version: 1.24, server API version: 1.22)")
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
2018-06-06 14:20:16,258 - flask.app - ERROR - 400 Client Error: Bad Request ("client is newer than server (client API version: 1.24, server API version: 1.22)")
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
APIError: 400 Client Error: Bad Request ("client is newer than server (client API version: 1.24, server API version: 1.22)")`



https://docker-py.readthedocs.io/en/1.2.3/api/#version