### PR TITLE
Bug fixes, Per CPU metrics, Better cpu and network labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here is a full list of the available environment variables you can set and a sho
   * Defaults to unix://var/run/docker.sock
 * USE_PSEUDO_FILES
   * Determines if the exporter will use the docker stats api or the cgroup and proc files to determines metrics. Metric names will be slightly different due to differences in parsing.
-  * Defaults to False
+  * Defaults to True
 * CGROUP_DIRECTORY
   * Determines the volume the service will parse for pseudo files
   * Defaults to /sys/fs/cgroup

--- a/src/application.py
+++ b/src/application.py
@@ -135,12 +135,12 @@ def parse_api_metrics(m):
                 make_line('blkio_stats_io_service_bytes_%s' % stat_name.lower(),
                           container, stat_value))
         network_stats = stats.get('networks')
-        for stat_name, interface_stats in six.iteritems(network_stats or {}):
+        for network_interface, interface_stats in six.iteritems(network_stats or {}):
             for metric_name, metric_value in six.iteritems(
                             interface_stats or {}):
+                network_labels = {"interface": network_interface}
                 lines.append(
-                    make_line('networks_%s_%s' % (stat_name, metric_name),
-                              container, metric_value))
+                    make_line('network_%s' % metric_name, container, metric_value, network_labels))
     lines.sort()
     string_buffer = "\n".join(lines)
     string_buffer += "\n"

--- a/src/application.py
+++ b/src/application.py
@@ -24,8 +24,7 @@ def is_enabled(variable, default):
 METRICS = None
 REFRESH_INTERVAL = int(os.environ.get('REFRESH_INTERVAL', 60))
 CONTAINER_REFRESH_INTERVAL = int(os.environ.get('CONTAINER_REFRESH_INTERVAL', 120))
-DOCKER_CLIENT = Client(
-    base_url=os.environ.get('DOCKER_CLIENT_URL', 'unix://var/run/docker.sock'), version='auto')
+DOCKER_CLIENT = Client(base_url=os.environ.get('DOCKER_CLIENT_URL', 'unix://var/run/docker.sock'), version='auto')
 USE_PSEUDO_FILES = is_enabled(os.environ.get('USE_PSEUDO_FILES'), True)
 CGROUP_DIRECTORY = os.environ.get('CGROUP_DIRECTORY', '/sys/fs/cgroup')
 PROC_DIRECTORY = os.environ.get('PROC_DIRECTORY', '/proc')
@@ -69,8 +68,7 @@ def handle_error(ex):
     response = jsonify(message=str(error))
     response.status_code = getattr(ex, 'code', 500)
     DOCKER_CLIENT = Client(
-        base_url=os.environ.get('DOCKER_CLIENT_URL',
-                                'unix://var/run/docker.sock'), version='auto')
+        base_url=os.environ.get('DOCKER_CLIENT_URL', 'unix://var/run/docker.sock'), version='auto')
     METRICS = update_metrics()
     return response
 

--- a/src/psuedo_file_metrics.py
+++ b/src/psuedo_file_metrics.py
@@ -84,10 +84,13 @@ class PseudoFileStats(object):
     def get_metrics(self):
         metrics = {}
         cpu = self.get_psuedo_stat_dir('cpu')
+        cpu_acct = self.get_psuedo_stat_dir('cpuacct')
         memory = self.get_psuedo_stat_dir('memory')
         blkio = self.get_psuedo_stat_dir('blkio')
         net = self.get_psuedo_stat_dir('net')
-        metrics['cpu'] = parse_pseduo_dir(cpu)
+        metrics['cpu'] = {}
+        for cpu_pseduo_file_directory in [cpu_acct, cpu]:
+            metrics['cpu'].update(parse_pseduo_dir(cpu_pseduo_file_directory))
         metrics['memory'] = parse_pseduo_dir(memory)
         metrics['blkio'] = parse_pseduo_dir(blkio)
         metrics['net'] = parse_net_dev(net)


### PR DESCRIPTION
* Add handling of truthy and falsey strings when setting the `USE_PSEUDO_FILES` environment variable
  * `false`, `no`, `0`, `disabled`, and empty values `''` are now accepted as falsy input
  * `true`, `yes`, `enabled`, `1` are now accepted as truthy values
  * All values are case insensitive, `TRUE` will evaluate the same as `true`
* Support for additional labels was added to `make_line` and `parse_line_value` functions
* Fixed parsing of percpu_usage metrics when using the docker stats API
  * cpu *core* number was added as an additional label for the `percpu_usage` metrics
* Add per cpu usage metrics when `USE_PSEUDO_FILES` is enabled. 
* Add better labels for network metrics
  * Each network interface is now added as a label for a given metric rather than as part of the metric name. This should allow more easily aggregating data from multiple network interfaces or when an interface name is unknown.

    